### PR TITLE
including SSL category in ball possession analysis

### DIFF
--- a/socceranalyzer/RobotSSL/extract_from_ssl_log.py
+++ b/socceranalyzer/RobotSSL/extract_from_ssl_log.py
@@ -16,24 +16,53 @@ class ExtractFromLog:
 
                 if timestamp == 0:
                     continue
+                
+                game_state_name = data['decision']['game_state_name']
 
-                data_line['game_state_name'] = data['decision']['game_state_name']
+                if game_state_name == 'Halt':
+                    continue
+
+                data_line['game_state_name'] = game_state_name
 
                 data_line['timestamp'] = timestamp
 
                 ball_data = process_frame['ball']
 
-                if 'position' in ball_data:
-                    data_line['position_x'] = ball_data['position']['x']
-                    data_line['position_y'] = ball_data['position']['y']
+                if 'position' in ball_data and 'velocity' in ball_data and 'acceleration' in ball_data:
+                    data_line['ball_position_x'] = ball_data['position']['x']
+                    data_line['ball_position_y'] = ball_data['position']['y']
 
-                if 'velocity' in ball_data:
-                    data_line['velocity_x'] = ball_data['velocity']['x']
-                    data_line['velocity_y'] = ball_data['velocity']['y']
+                    data_line['ball_velocity_x'] = ball_data['velocity']['x']
+                    data_line['ball_velocity_y'] = ball_data['velocity']['y']
+
+                    data_line['ball_acceleration_x'] = ball_data['acceleration']['x']
+                    data_line['ball_acceleration_y'] = ball_data['acceleration']['y']
+                else:
+                    continue
                 
-                if 'acceleration' in ball_data:
-                    data_line['acceleration_x'] = ball_data['acceleration']['x']
-                    data_line['acceleration_y'] = ball_data['acceleration']['y']
+                allies = process_frame['allies']
+                enemies = process_frame['enemies']
+
+                if (len(allies) == 6 and len(enemies) == 6):
+                    for ally in allies:
+                        id = str(ally['id'])
+
+                        data_line[f'ally_{id}_position_x'] = ally['position']['x']
+                        data_line[f'ally_{id}_position_y'] = ally['position']['y']
+
+                        data_line[f'ally_{id}_velocity_x'] = ally['velocity']['x']
+                        data_line[f'ally_{id}_velocity_y'] = ally['velocity']['y']
+
+                    for enemy in enemies:
+                        id = str(enemy['id'])
+
+                        data_line[f'enemy_{id}_position_x'] = enemy['position']['x']
+                        data_line[f'enemy_{id}_position_y'] = enemy['position']['y']
+
+                        data_line[f'enemy_{id}_velocity_x'] = enemy['velocity']['x']
+                        data_line[f'enemy_{id}_velocity_y'] = enemy['velocity']['y']
+                else:
+                    continue
 
                 frame_data.append(data_line)
         

--- a/socceranalyzer/common/analysis/ball_possession.py
+++ b/socceranalyzer/common/analysis/ball_possession.py
@@ -1,6 +1,9 @@
 from socceranalyzer.common.enums.sim2d import SIM2D
-from socceranalyzer.common.evaluators.ball_holder import BallHolderEvaluator
+from socceranalyzer.common.enums.ssl import SSL
 from socceranalyzer.utils.logger import Logger
+from socceranalyzer.common.chore.mediator import Mediator
+from socceranalyzer.common.geometric.point import Point
+from socceranalyzer.common.operations.measures import distance_sqrd
 
 class BallPossession:
     """
@@ -42,6 +45,11 @@ class BallPossession:
         self.__current_game_log = data_frame
         self.__total = 0
 
+        # Left players stand for RoboCIn team in SSL category
+        self.__players_left = Mediator.players_left_position(self.category)
+        self.__players_right = Mediator.players_right_position(self.category)
+        self.__ball_range = 10 ** 2
+
         try:
             self.__calculate()
         except Exception as err:
@@ -65,30 +73,71 @@ class BallPossession:
 
     def __calculate(self):
         """
-            Uses socceranalyzer.common.evaluators.ball_holder to populate left_team_possession and right_team_possession
+            Populates left_team_possession and right_team_possession using the ball_holder method
         """
-        filtered_game = self.__filter_playmode('play_on')
+        filtered_game = self.__filter_playmode(str(self.category.RUNNING_GAME))
 
-        ball_holder_analysis = BallHolderEvaluator(filtered_game, self.category)
+        filtered_game['ball_possession'] = filtered_game.apply(self.__ball_holder, axis=1)
 
-        for current_cycle, row in filtered_game.iterrows():
-            closest_side = ball_holder_analysis.at(current_cycle)[2]
-
-            if closest_side == 'left':
-                self.__left_team_possession += 1
-            else:
-                self.__right_team_possession += 1
+        self.__left_team_possession = filtered_game['ball_possession'].value_counts()['L']
+        self.__right_team_possession = filtered_game['ball_possession'].value_counts()['R']
 
         self.__total = self.__right_team_possession + self.__left_team_possession
 
+    def __ball_holder(self, df_row):
+        """
+            Receives a dataframe's row as argument and calculates the closest player to the ball to compute
+            who has its possession. If two enemy players are within ball range, none receive its holder
+            status
+        """
+        left_distance = float('inf')
+        right_distance = float('inf')
+
+        ball_x = df_row[str(self.category.BALL_X)]
+        ball_y = df_row[str(self.category.BALL_Y)]
+        ball_position = Point(ball_x, ball_y)
+
+        for i in range(len(self.__players_left.items)):
+            player_x = df_row[self.__players_left.items[i].x]
+            player_y = df_row[self.__players_left.items[i].y]
+
+            player_position = Point(player_x, player_y)
+
+            player_distance = distance_sqrd(player_position, ball_position)
+
+            if (player_distance < left_distance):
+                left_distance = player_distance
+
+        for i in range(len(self.__players_right.items)):
+            player_x = df_row[self.__players_right.items[i].x]
+            player_y = df_row[self.__players_right.items[i].y]
+
+            player_position = Point(player_x, player_y)
+
+            player_distance = distance_sqrd(player_position, ball_position)
+
+            if (player_distance < right_distance):
+                right_distance = player_distance
+        
+        if (abs(left_distance - right_distance) <= self.__ball_range):
+            return 'D' # ball in dispute
+        elif (left_distance < right_distance):
+            return 'L'
+        elif (right_distance < left_distance):
+            return 'R'
+        
     def results(self):
         return (self.__left_team_possession / self.__total, self.__right_team_possession / self.__total)
 
     def describe(self):
-        name_l = self.__current_game_log.loc[1, str(self.category.TEAM_LEFT)]
-        name_r = self.__current_game_log.loc[1, str(self.category.TEAM_RIGHT)]
-        print(f'{name_l}: {self.__left_team_possession/self.__total}\n' 
-                f'{name_r}: {self.__right_team_possession/self.__total}')
+        if (self.category == SIM2D):
+            name_l = self.__current_game_log.loc[1, str(self.category.TEAM_LEFT)]
+            name_r = self.__current_game_log.loc[1, str(self.category.TEAM_RIGHT)]
+            print(f'{name_l}: {self.__left_team_possession/self.__total}\n' 
+                    f'{name_r}: {self.__right_team_possession/self.__total}')
+        elif (self.category == SSL):
+            print(f'RoboCIN: {(self.__left_team_possession/self.__total * 100):.2f}%\n' 
+                    f'Enemy: {(self.__right_team_possession/self.__total * 100):.2f}%')
 
     def serialize(self):
         raise NotImplementedError

--- a/socceranalyzer/common/chore/match_analyzer.py
+++ b/socceranalyzer/common/chore/match_analyzer.py
@@ -313,7 +313,9 @@ class MatchAnalyzer(AbstractFactory):
             #self.__time_after_corner = TimeAfterCorner(self.__match.dataframe, self.category)
 
         elif self.__cat is SSL:
-            pass
+            if self.config.ball_possession:
+                setattr(self, "__ball_possession", None)
+                self.__ball_possession = BallPossession(self.__match.dataframe, self.category, self._DEBUG)
             # setattr(self, "__heatmap", None)
             # self.__heatmap = Heatmap(self.__match.dataframe, self.category)
 

--- a/socceranalyzer/common/chore/mediator.py
+++ b/socceranalyzer/common/chore/mediator.py
@@ -35,10 +35,18 @@ class Mediator:
 
             return slp
 
-        elif category is VSS:
-            raise NotImplementedError
-
+        # For SSL this is the RoboCIn team
         elif category is SSL:
+            if gkeeper:
+                for i in range(0, 6):
+                    slp.items.append(StringListItem(f'ally_{i}_position_x', f'ally_{i}_position_y'))
+            else:
+                for i in range(1, 6):
+                    slp.items.append(StringListItem(f'ally_{i}_position_x', f'ally_{i}_position_y'))
+
+            return slp
+
+        elif category is VSS:
             raise NotImplementedError
 
     @staticmethod
@@ -55,10 +63,19 @@ class Mediator:
                     slp.items.append(StringListItem(f'player_r{i}_x', f'player_r{i}_y'))
 
             return slp
-        elif category is VSS:
-            raise NotImplementedError
-
+        
+        # For SSL this is the enemy team
         elif category is SSL:
+            if gkeeper:
+                for i in range(0, 6):
+                    slp.items.append(StringListItem(f'enemy_{i}_position_x', f'enemy_{i}_position_y'))
+            else:
+                for i in range(1, 6):
+                    slp.items.append(StringListItem(f'enemy_{i}_position_x', f'enemy_{i}_position_y'))
+
+            return slp
+
+        elif category is VSS:
             raise NotImplementedError
 
     @staticmethod

--- a/socceranalyzer/common/enums/ssl.py
+++ b/socceranalyzer/common/enums/ssl.py
@@ -12,12 +12,12 @@ class SSL(Enum):
     """
 
     GAME_TIME = "showtime"
-    PLAYMODE = "playmode"
-    RUNNING_GAME = "UNKNOWN"
+    PLAYMODE = "game_state_name"
+    RUNNING_GAME = "GameRunning"
     # FAULT_COMMITED_L = "foul_charge_l"
     # FAULT_COMMITED_R = "foul_charge_r"
-    BALL_X = "ball_x"
-    BALL_Y = "ball_y"
+    BALL_X = "ball_position_x"
+    BALL_Y = "ball_position_y"
     BALL_VX = "ball_vx",
     BALL_VY = "ball_vy",
     TEAM_LEFT = "team_l_name"


### PR DESCRIPTION
Mudanças para permitir a análise de posse de bola para a categoria SSL:
- Alguns parâmetros hardcodados para 2D foram substituídos para os enums das categorias
- Criei uma nova função para ball holder que retorna apenas a posse de bola. Fiz ela de forma a receber uma linha do dataframe e poder ser facilmente utilizada com o método _apply_
- Agora, se 2 players de times diferentes estiverem perto da bola, ela será tomada como em disputa e nenhum dos dois receberá a posse